### PR TITLE
Fail iotools tests

### DIFF
--- a/.github/workflows/pytest-remote-data.yml
+++ b/.github/workflows/pytest-remote-data.yml
@@ -92,7 +92,7 @@ jobs:
         run: pytest pvlib/tests/iotools --cov=./ --cov-report=xml --remote-data
 
       - name: Upload coverage to Codecov
-        if: matrix.python-version == 3.9
+        if: matrix.python-version == 3.6
         uses: codecov/codecov-action@v2
         with:
           fail_ci_if_error: true

--- a/.github/workflows/pytest-remote-data.yml
+++ b/.github/workflows/pytest-remote-data.yml
@@ -89,7 +89,7 @@ jobs:
           NREL_API_KEY: ${{ secrets.NRELAPIKEY }}
           BSRN_FTP_USERNAME: ${{ secrets.BSRN_FTP_USERNAME }}
           BSRN_FTP_PASSWORD: ${{ secrets.BSRN_FTP_PASSWORD }}
-        run: pytest pvlib/tests/iotools --cov=./ --cov-report=xml --remote-data
+        run: pytest pvlib/tests/iotools pvlib/tests/test_forecast.py --cov=./ --cov-report=xml --remote-data
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == 3.6
@@ -97,4 +97,4 @@ jobs:
         with:
           fail_ci_if_error: true
           verbose: true
-          flags: iotools  # flags are configured in codecov.yml
+          flags: remote-data  # flags are configured in codecov.yml

--- a/.github/workflows/pytest-remote-data.yml
+++ b/.github/workflows/pytest-remote-data.yml
@@ -1,0 +1,100 @@
+# A secondary test job that only runs the iotools tests if explicitly requested.
+# Because the iotools tests require GitHub secrets, we need to be careful about 
+# malicious PRs accessing the secrets and exposing them externally.
+#
+# We prevent this by only running this workflow when a maintainer has looked
+# over the PR's diff and verified that nothing malicious seems to be going on.
+# The maintainer then adds the "remote-data" label to the PR, which will then
+# trigger this workflow via the combination of the "on: ... types:"
+# and "if:" sections below.  The first restricts the workflow to only run when
+# a label is added to the PR and the second requires one of the PR's labels
+# is the "remote-data" label.  Technically this is slightly different from
+# triggering when the "remote-data" label is added, since it will also trigger
+# when "remote-data" is added, then later some other label is added.  Maybe
+# there's a better way to do this.
+#
+# But wait, you say!  Can't a malicious PR get around this by modifying
+# this workflow file and removing the label requirement?  I think the answer
+# is "no" as long as we trigger the workflow on "pull_request_target" instead
+# of the usual "pull_request".  The difference is what context the workflow
+# runs inside: "pull_request" runs in the context of the fork, where changes
+# to the workflow definition will take immediate effect, while "pull_request_target"
+# runs in the context of the main pvlib repository, where the original (non-fork)
+# workflow definition is used instead.  Of course by switching away from the fork's
+# context to keep our original workflow definitions, we're also keeping all the
+# original code, so the tests won't be run against the PR's new code.  To fix this
+# we explicitly check out the PR's code as the first step of the workflow.
+# So long as a maintainer always verifies that the PR's code is not malicious prior to
+# adding the label and triggering this workflow, this should not present a security risk.
+#
+# Note that this workflow can be triggered again by removing and re-adding the
+# "remote-data" label to the PR.
+#
+# Note also that "pull_request_target" is also the only way for the secrets
+# to be accessible in the first place.
+# 
+# Further reading:
+# - https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+# - https://github.community/t/can-workflow-changes-be-used-with-pull-request-target/178626/7
+
+name: pytest-remote-data
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+jobs:
+  test:
+    env:
+      # we need to turn "3.6" into 36 to build the conda requirement filename,
+      # but there's no good way to do that via string manipulation.  So set up
+      # a map that will be parsed as JSON later:
+      VERSIONMAP: '{"3.6": "36", "3.7": "37", "3.8": "38", "3.9": "39"}'
+
+    strategy:
+      fail-fast: false  # don't cancel other matrix jobs when one fails
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9]
+        suffix: ['']  # placeholder as an alternative to "-min"
+        include:
+          - python-version: 3.6
+            suffix: -min
+
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'remote-data')
+
+    steps:
+      - uses: actions/checkout@v2
+        # pull_request_target runs in the context of the target branch (pvlib/master),
+        # but what we need is the hypothetical merge commit from the PR:
+        with:
+          ref: "refs/pull/${{ github.event.number }}/merge"
+
+      - name: Set up conda environment
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: test_env
+          environment-file: ${{ env.REQUIREMENTS }}
+          python-version: ${{ matrix.python-version }}
+          auto-activate-base: false
+        env:
+          # build requirement filename.  First replacement is for the python
+          # version, mapping from "3.7" to "37", second is to add "-min" if needed
+          REQUIREMENTS: ci/requirements-py${{ fromJSON(env.VERSIONMAP)[matrix.python-version] }}${{ matrix.suffix }}.yml
+
+      - name: Run tests
+        shell: bash -l {0}  # necessary for conda env to be active
+        env:
+          # copy GitHub Secrets into environment variables for the tests to access
+          NREL_API_KEY: ${{ secrets.NRELAPIKEY }}
+          BSRN_FTP_USERNAME: ${{ secrets.BSRN_FTP_USERNAME }}
+          BSRN_FTP_PASSWORD: ${{ secrets.BSRN_FTP_PASSWORD }}
+        run: pytest pvlib/tests/iotools --cov=./ --cov-report=xml --remote-data
+
+      - name: Upload coverage to Codecov
+        if: matrix.python-version == 3.9
+        uses: codecov/codecov-action@v2
+        with:
+          fail_ci_if_error: true
+          verbose: true
+          flags: iotools  # flags are configured in codecov.yml

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -57,6 +57,14 @@ jobs:
         if: matrix.environment-type == 'bare'
         run: pip install .[test]
 
+      - name: Show environment
+        run: |
+          which python
+          pip freeze
+          pip show siphon
+          ls -al 
+        
+
       - name: Run tests
         shell: bash -l {0}  # necessary for conda env to be active
         run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -64,7 +64,7 @@ jobs:
           pytest pvlib --cov=./ --cov-report=xml --ignore=pvlib/tests/iotools
 
       - name: Upload coverage to Codecov
-        if: matrix.python-version == 3.9 && matrix.os == 'ubuntu-latest' && matrix.environment-type == 'conda'
+        if: matrix.python-version == 3.6 && matrix.os == 'ubuntu-latest' && matrix.environment-type == 'conda'
         uses: codecov/codecov-action@v2
         with:
           fail_ci_if_error: true

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,72 @@
+name: pytest
+
+on: [pull_request, push]
+
+jobs:
+  test:
+    env:
+      # we need to turn "3.6" into 36 to build the conda requirement filename,
+      # but there's no good way to do that via string manipulation.  So set up
+      # a map that will be parsed as JSON later:
+      VERSIONMAP: '{"3.6": "36", "3.7": "37", "3.8": "38", "3.9": "39"}'
+
+    strategy:
+      fail-fast: false  # don't cancel other matrix jobs when one fails
+      matrix:
+        # use macos-10.15 instead of macos-latest for py3.6 support
+        os: [ubuntu-latest, macos-10.15, windows-latest]
+        python-version: [3.6, 3.7, 3.8, 3.9]
+        environment-type: [conda, bare]
+        suffix: ['']  # placeholder as an alternative to "-min"
+        include:
+          - os: ubuntu-latest
+            python-version: 3.6
+            environment-type: conda
+            suffix: -min
+        exclude:
+          - os: macos-latest
+            environment-type: conda
+          - os: windows-latest
+            environment-type: bare
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up conda environment
+        if: matrix.environment-type == 'conda'
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: test_env
+          environment-file: ${{ env.REQUIREMENTS }}
+          python-version: ${{ matrix.python-version }}
+          auto-activate-base: false
+        env:
+          # build requirement filename.  First replacement is for the python
+          # version, mapping from "3.7" to "37", second is to add "-min" if needed
+          REQUIREMENTS: ci/requirements-py${{ fromJSON(env.VERSIONMAP)[matrix.python-version] }}${{ matrix.suffix }}.yml
+
+      - name: Install Python ${{ matrix.python-version }}${{ matrix.suffix }}
+        if: matrix.environment-type == 'bare'
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Set up bare environment
+        if: matrix.environment-type == 'bare'
+        run: pip install .[test]
+
+      - name: Run tests
+        shell: bash -l {0}  # necessary for conda env to be active
+        run: |
+          # ignore iotools; those tests are run in a separate workflow
+          pytest pvlib --cov=./ --cov-report=xml --ignore=pvlib/tests/iotools
+
+      - name: Upload coverage to Codecov
+        if: matrix.python-version == 3.9 && matrix.os == 'ubuntu-latest' && matrix.environment-type == 'conda'
+        uses: codecov/codecov-action@v2
+        with:
+          fail_ci_if_error: true
+          verbose: true
+          flags: core  # flags are configured in codecov.yml

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -61,7 +61,7 @@ jobs:
         shell: bash -l {0}  # necessary for conda env to be active
         run: |
           # ignore iotools & forecast; those tests are run in a separate workflow
-          pytest --verbose pvlib --cov=./ --cov-report=xml --ignore=pvlib/tests/iotools --ignore=pvlib/tests/test_forecast.py
+          pytest pvlib --cov=./ --cov-report=xml --ignore=pvlib/tests/iotools --ignore=pvlib/tests/test_forecast.py
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == 3.6 && matrix.suffix == '' && matrix.os == 'ubuntu-latest' && matrix.environment-type == 'conda'

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -24,7 +24,7 @@ jobs:
             environment-type: conda
             suffix: -min
         exclude:
-          - os: macos-latest
+          - os: macos-10.15
             environment-type: conda
           - os: windows-latest
             environment-type: bare

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -58,6 +58,7 @@ jobs:
         run: pip install .[test]
 
       - name: Show environment
+        shell: bash -l {0}  # necessary for conda env to be active
         run: |
           which python
           pip freeze

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -57,17 +57,11 @@ jobs:
         if: matrix.environment-type == 'bare'
         run: pip install .[test]
 
-      - name: Show environment
-        shell: bash -l {0}  # necessary for conda env to be active
-        run: |
-          which python
-          pip freeze
-
       - name: Run tests
         shell: bash -l {0}  # necessary for conda env to be active
         run: |
-          # ignore iotools; those tests are run in a separate workflow
-          pytest --verbose pvlib --cov=./ --cov-report=xml --ignore=pvlib/tests/iotools
+          # ignore iotools & forecast; those tests are run in a separate workflow
+          pytest --verbose pvlib --cov=./ --cov-report=xml --ignore=pvlib/tests/iotools --ignore=pvlib/tests/test_forecast.py
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == 3.6 && matrix.suffix == '' && matrix.os == 'ubuntu-latest' && matrix.environment-type == 'conda'

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -64,7 +64,7 @@ jobs:
           pytest pvlib --cov=./ --cov-report=xml --ignore=pvlib/tests/iotools
 
       - name: Upload coverage to Codecov
-        if: matrix.python-version == 3.6 && matrix.os == 'ubuntu-latest' && matrix.environment-type == 'conda'
+        if: matrix.python-version == 3.6 && matrix.suffix == '' && matrix.os == 'ubuntu-latest' && matrix.environment-type == 'conda'
         uses: codecov/codecov-action@v2
         with:
           fail_ci_if_error: true

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -62,15 +62,12 @@ jobs:
         run: |
           which python
           pip freeze
-          pip show siphon
-          ls -al 
-        
 
       - name: Run tests
         shell: bash -l {0}  # necessary for conda env to be active
         run: |
           # ignore iotools; those tests are run in a separate workflow
-          pytest pvlib --cov=./ --cov-report=xml --ignore=pvlib/tests/iotools
+          pytest --verbose pvlib --cov=./ --cov-report=xml --ignore=pvlib/tests/iotools
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == 3.6 && matrix.suffix == '' && matrix.os == 'ubuntu-latest' && matrix.environment-type == 'conda'

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,10 +3,10 @@ codecov:
     require_ci_to_pass: no
 
 # "flags" are used to identify subsets of the overall codebase when calculating coverage.
-# Currently used for "iotools" (pvlib.iotools) and "core" (everything except pvlib.iotools).
-# Because we only run the iotools tests sometimes, we need to split it out so that
+# Currently used for "remote_data" (pvlib.iotools & forecast) and "core" (everything else).
+# Because we only run the remote_data tests sometimes, we need to split it out so that
 # codecov doesn't report a big drop in coverage when we don't run them.
-# We also use "carryforward: true" so that, when we don't run iotools tests, the last
+# We also use "carryforward: true" so that, when we don't run remote_data tests, the last
 # known coverage is carried forward and used in place of the missing coverage.
 # https://docs.codecov.com/docs/flags
 flags:
@@ -15,11 +15,13 @@ flags:
     paths:
       - pvlib/
       - '!pvlib/iotools/'
+      - '!pvlib/forecast.py'
     carryforward: false
 
-  iotools:
+  remote-data:
     paths:
       - pvlib/iotools/
+      - pvlib/forecast.py
     carryforward: true  # if not run, use coverage from previous commit
 
 
@@ -36,25 +38,27 @@ coverage:
         flags:
           - core
 
-      iotools:
+      remote-data:
         target: auto
         flags:
-          - iotools
+          - remote-data
 
       tests-core:
         target: 95%
         paths:
           - 'pvlib/tests/.*'
           - '!pvlib/tests/iotools/.*'
+          - '!pvlib/tests/test_forecast.py'
         flags:
           - core
 
-      tests-iotools:
+      tests-remote-data:
         target: 95%
         paths:
-          - "pvlib/tests/iotools/.*"
+          - 'pvlib/tests/iotools/.*'
+          - 'pvlib/tests/test_forecast.py'
         flags:
-          - iotools
+          - remote-data
 
 
 comment: off

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,26 +2,51 @@ codecov:
   notify:
     require_ci_to_pass: no
 
+# "flags" are used to identify subsets of the overall codebase when calculating coverage.
+# Currently used for "iotools" (pvlib.iotools) and "core" (everything except pvlib.iotools).
+# Because we only run the iotools tests sometimes, we need to split it out so that
+# codecov doesn't report a big drop in coverage when we don't run them.
+# We also use "carryforward: true" so that, when we don't run iotools tests, the last
+# known coverage is carried forward and used in place of the missing coverage.
+# https://docs.codecov.com/docs/flags
+flags:
+
+  core:
+    paths:
+      - pvlib/
+      - '!pvlib/iotools/'
+    carryforward: false
+
+  iotools:
+    paths:
+      - pvlib/iotools/
+    carryforward: true  # if not run, use coverage from previous commit
+
+
 coverage:
   status:
     patch:
       default:
         target: 100%
-        if_no_uploads: error
-        if_not_found: success
-        if_ci_failed: failure
+
     project:
-      default: false
-      library:
+      default: off
+      core:
         target: auto
-        if_no_uploads: error
-        if_not_found: success
-        if_ci_failed: failure
-        paths:
-          - "pvlib/.*"
+        flags:
+          - core
+
+      iotools:
+        target: auto
+        flags:
+          - iotools
+
       tests:
         target: 95%
         paths:
           - "pvlib/tests/.*"
+        flags:
+          - core
+          - iotools
 
 comment: off

--- a/codecov.yml
+++ b/codecov.yml
@@ -41,12 +41,20 @@ coverage:
         flags:
           - iotools
 
-      tests:
+      tests-core:
         target: 95%
         paths:
-          - "pvlib/tests/.*"
+          - 'pvlib/tests/.*'
+          - '!pvlib/tests/iotools/.*'
         flags:
           - core
+
+      tests-iotools:
+        target: 95%
+        paths:
+          - "pvlib/tests/iotools/.*"
+        flags:
           - iotools
+
 
 comment: off

--- a/pvlib/iotools/psm3.py
+++ b/pvlib/iotools/psm3.py
@@ -148,6 +148,7 @@ def get_psm3(latitude, longitude, api_key, email, names='tmy', interval=60,
     .. [4] `Physical Solar Model (PSM) v3 - Five Minute Temporal Resolution
        <https://developer.nrel.gov/docs/solar/nsrdb/psm3-5min-download/>`_
     """
+    make_an_error
     # The well know text (WKT) representation of geometry notation is strict.
     # A POINT object is a string with longitude first, then the latitude, with
     # four decimals each, and exactly one space between them.

--- a/pvlib/tests/conftest.py
+++ b/pvlib/tests/conftest.py
@@ -144,7 +144,8 @@ requires_numba = pytest.mark.skipif(not has_numba(), reason="requires numba")
 try:
     import siphon
     has_siphon = True
-except ImportError:
+except ImportError as e:
+    print(str(e))
     has_siphon = False
 
 requires_siphon = pytest.mark.skipif(not has_siphon,


### PR DESCRIPTION
Introduce an error in get_psm3, which should pass on the initial CI run but fail after the remote-data label is added.